### PR TITLE
Fix unnecessary quoting of strings with colons in multiline blocks

### DIFF
--- a/lib/github_workflows_generator/yml_encoder.ex
+++ b/lib/github_workflows_generator/yml_encoder.ex
@@ -32,7 +32,7 @@ defmodule GithubWorkflowsGenerator.YmlEncoder do
         values =
           data
           |> String.split("\n", trim: true)
-          |> Enum.map_join("\n", &(String.duplicate("  ", level) <> value(&1)))
+          |> Enum.map_join("\n", &(String.duplicate("  ", level) <> &1))
 
         "|\n#{values}"
 

--- a/test/github_workflows_generator/yml_encoder_test.exs
+++ b/test/github_workflows_generator/yml_encoder_test.exs
@@ -29,6 +29,14 @@ defmodule GithubWorkflowsGenerator.YmlEncoderTest do
              """
     end
 
+    test "encodes a multiline string with colons correctly" do
+      assert YmlEncoder.encode(example: "this: is valid\nanother: line") == """
+             example: |
+               this: is valid
+               another: line
+             """
+    end
+
     test "encodes a complex data structure" do
       assert YmlEncoder.encode(
                on: [


### PR DESCRIPTION
## Summary
- Fixes #4 - Strings containing colons are no longer unnecessarily quoted in multiline YAML blocks
- Multiline strings already use the `|` indicator, so individual lines don't need quoting

## Changes
- Modified `YmlEncoder` to not apply the `value/1` function to lines within multiline blocks
- Added test case to verify multiline strings with colons work correctly

## Test plan
- [x] All existing tests pass
- [x] Added new test for multiline strings containing colons
- [x] CI checks pass (formatting, Credo, Dialyzer)
- [x] 100% test coverage maintained